### PR TITLE
Update lighting table structure

### DIFF
--- a/comprehensive_table.html
+++ b/comprehensive_table.html
@@ -13,30 +13,37 @@
 <h1>プレミアムミニバン装備 一覧</h1>
 <table>
 <tr>
-  <th>装備項目＼モデル</th>
-  <th>J1 Alphard 40</th>
-  <th>J2 Alphard 30</th>
-  <th>J3 Elgrand E52</th>
-  <th>J4 Lexus LM 1st</th>
-  <th>J5 Lexus LM 2nd</th>
-  <th>C1 GL8 Avenir</th>
-  <th>C2 GL8 Century</th>
-  <th>C3 Hongqi HQ9</th>
-  <th>C4 Voyah Dreamer</th>
-  <th>C5 GAC M8</th>
-  <th>C6 Denza D9</th>
-  <th>E1 V-Class</th>
-  <th>E2 Multivan T7</th>
-  <th>E3 Transporter T6</th>
-  <th>E4 Traveller</th>
-  <th>E5 Marco Polo</th>
-  <th>N1 Sienna</th>
-  <th>N2 Odyssey</th>
-  <th>N3 Pacifica</th>
-  <th>N4 Carnival US</th>
-  <th>K1 Carnival KR</th>
-  <th>K2 Hi-Limo</th>
-  <th>K3 Staria Limo</th>
+  <th rowspan="2">装備項目＼モデル</th>
+  <th colspan="5">日本</th>
+  <th colspan="6">中国</th>
+  <th colspan="5">欧州</th>
+  <th colspan="4">北米</th>
+  <th colspan="3">韓国</th>
+</tr>
+<tr>
+  <th>Alphard 40</th>
+  <th>Alphard 30</th>
+  <th>Elgrand E52</th>
+  <th>Lexus LM 1st</th>
+  <th>Lexus LM 2nd</th>
+  <th>GL8 Avenir</th>
+  <th>GL8 Century</th>
+  <th>Hongqi HQ9</th>
+  <th>Voyah Dreamer</th>
+  <th>GAC M8</th>
+  <th>Denza D9</th>
+  <th>V-Class</th>
+  <th>Multivan T7</th>
+  <th>Transporter T6</th>
+  <th>Traveller</th>
+  <th>Marco Polo</th>
+  <th>Sienna</th>
+  <th>Odyssey</th>
+  <th>Pacifica</th>
+  <th>Carnival US</th>
+  <th>Carnival KR</th>
+  <th>Hi-Limo</th>
+  <th>Staria Limo</th>
 </tr>
 <tr>
   <td>外観リンク</td>
@@ -116,6 +123,32 @@
   <td>▲</td>
 </tr>
 <tr>
+  <td>照明名称（写真）</td>
+  <td>LED 64色 <a href="https://toyota.jp/pages/contents/alphard/004_p_001/image/design/interior_07_01.jpg">Pic</a></td>
+  <td>LED 16色 <a href="https://car.watch.impress.co.jp/img/car/docs/1098/874/620.jpg">Pic</a></td>
+  <td>ダウンライト <a href="https://www3.nissan.co.jp/content/dam/Nissan/jp/vehicles/elgrand/design/img/interior/interior_5.jpg">Pic</a></td>
+  <td>Roof LED <a href="https://www.lexus.com.my/content/dam/lexus-my/models/lm/2022/gallery/lexus-lm-interior-1.jpg">Pic</a></td>
+  <td>Galaxy Ceiling <a href="https://global.toyota/en/album/images/39084541/1">Pic</a></td>
+  <td>128色 <a href="https://www.buick.com.cn/content/dam/website/gmcm/cn/zh/vehicles/buick/mpv/gl8-avenir/gallery/interior/01.jpg">Pic</a></td>
+  <td>星�穹顶 <a href="https://www.buick.com.cn/content/dam/website/gmcm/cn/zh/vehicles/buick/mpv/century/gallery/interior/05.jpg">Pic</a></td>
+  <td>星空顶 <a href="https://car3.autoimg.cn/cardfs/product/resize/650x/20221031_123550_135.jpg">Pic</a></td>
+  <td>星空顶 <a href="https://car2.autoimg.cn/cardfs/product/resize/650x/20230606_123937_256.jpg">Pic</a></td>
+  <td>星光顶 <a href="https://www.gacmotor.com/uploads/m8/interior_3.jpg">Pic</a></td>
+  <td>星空顶 <a href="https://www.denza.com/images/d9/gallery/int_04.jpg">Pic</a></td>
+  <td>64-col <a href="https://www.mercedes-benz.co.uk/content/dam/retail-uk/mercedes-benz-cars/uk/vans/v-class/gallery/12_V_04.jpg">Pic</a></td>
+  <td>30-col <a href="https://www.volkswagen.de/content/dam/vwd4/de/multivan/_jcr_content/gallery_513/galleryitem_2/image.img.jpg">Pic</a></td>
+  <td>白色LED</td>
+  <td>LEDライン</td>
+  <td>3-col</td>
+  <td>Mood</td>
+  <td>LED Spots</td>
+  <td>Ambient Dome</td>
+  <td>LED Cabin</td>
+  <td>LEDライン</td>
+  <td>Star-roof <a href="https://www.kia.com/content/dam/kia2/in/en/images/showroom/carnival-hi-limousine/gallery/hi-limo_int02.jpg">Pic</a></td>
+  <td>Starry Mood <a href="https://www.hyundai.com/contents/vehicle/staria-lounge-limousine/images/gallery/limousine_int_03.jpg">Pic</a></td>
+</tr>
+<tr>
   <td>読書灯／機能灯</td>
   <td>●</td>
   <td>●</td>
@@ -142,31 +175,6 @@
   <td>●</td>
 </tr>
 <tr>
-  <td>照明名称（写真）</td>
-  <td>LED 64色 <a href="https://toyota.jp/pages/contents/alphard/004_p_001/image/design/interior_07_01.jpg">Pic</a></td>
-  <td>LED 16色 <a href="https://car.watch.impress.co.jp/img/car/docs/1098/874/620.jpg">Pic</a></td>
-  <td>ダウンライト <a href="https://www3.nissan.co.jp/content/dam/Nissan/jp/vehicles/elgrand/design/img/interior/interior_5.jpg">Pic</a></td>
-  <td>Roof LED <a href="https://www.lexus.com.my/content/dam/lexus-my/models/lm/2022/gallery/lexus-lm-interior-1.jpg">Pic</a></td>
-  <td>Galaxy Ceiling <a href="https://global.toyota/en/album/images/39084541/1">Pic</a></td>
-  <td>128色 <a href="https://www.buick.com.cn/content/dam/website/gmcm/cn/zh/vehicles/buick/mpv/gl8-avenir/gallery/interior/01.jpg">Pic</a></td>
-  <td>星�穹顶 <a href="https://www.buick.com.cn/content/dam/website/gmcm/cn/zh/vehicles/buick/mpv/century/gallery/interior/05.jpg">Pic</a></td>
-  <td>星空顶 <a href="https://car3.autoimg.cn/cardfs/product/resize/650x/20221031_123550_135.jpg">Pic</a></td>
-  <td>星空顶 <a href="https://car2.autoimg.cn/cardfs/product/resize/650x/20230606_123937_256.jpg">Pic</a></td>
-  <td>星光顶 <a href="https://www.gacmotor.com/uploads/m8/interior_3.jpg">Pic</a></td>
-  <td>星空顶 <a href="https://www.denza.com/images/d9/gallery/int_04.jpg">Pic</a></td>
-  <td>64-col <a href="https://www.mercedes-benz.co.uk/content/dam/retail-uk/mercedes-benz-cars/uk/vans/v-class/gallery/12_V_04.jpg">Pic</a></td>
-  <td>30-col <a href="https://www.volkswagen.de/content/dam/vwd4/de/multivan/_jcr_content/gallery_513/galleryitem_2/image.img.jpg">Pic</a></td>
-  <td>白色LED</td>
-  <td>LEDライン</td>
-  <td>3-col</td>
-  <td>Mood</td>
-  <td>LED Spots</td>
-  <td>Ambient Dome</td>
-  <td>LED Cabin</td>
-  <td>LEDライン</td>
-  <td>Star-roof <a href="https://www.kia.com/content/dam/kia2/in/en/images/showroom/carnival-hi-limousine/gallery/hi-limo_int02.jpg">Pic</a></td>
-  <td>Starry Mood <a href="https://www.hyundai.com/contents/vehicle/staria-lounge-limousine/images/gallery/limousine_int_03.jpg">Pic</a></td>
-</tr>
 <tr>
   <td>パノラマ／ツインSR</td>
   <td>▲</td>


### PR DESCRIPTION
## Summary
- organize models under regional headers in `comprehensive_table.html`
- move the lighting name row directly below the `ロングOHC` row

## Testing
- `curl -I https://toyota.jp/alphard/design/ | head -n 1` *(fails: CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_686d27deddcc8326a409277fdcc4abde